### PR TITLE
Return 404 for non-existent counter test added

### DIFF
--- a/tdd_lab/src/counter.py
+++ b/tdd_lab/src/counter.py
@@ -92,6 +92,20 @@ def get_counter(name):
     return jsonify({"error": "Counter not found"}), 404
 
 # ===========================
+# Test: Return 404 for non-existent counter (GET /counters)
+# Author: Aviendha Andrus
+# Date: 2025-02-06
+# Description: GET endpoint to retrieve a 404 error if counter does not exist
+# this test is also covered by get_counter function above
+# ===========================
+@app.route('/counters/<name>', methods=['GET'])
+def return_nonexistant(name):
+    """Return 404 if not found"""
+    if name not in COUNTERS:
+        return jsonify({"error": f"Counter not found"}), status.HTTP_404_NOT_FOUND
+    return jsonify({name: COUNTERS[name]}), status.HTTP_200_OK
+
+# ===========================
 # Feature: List all counters
 # Author: Christopher Liscano
 # Date: 2025-02-04

--- a/tdd_lab/tests/test_counter.py
+++ b/tdd_lab/tests/test_counter.py
@@ -145,6 +145,20 @@ class TestCounterEndpoints:
         assert "test_counter" in data
 
     # ===========================
+    # Test: Return 404 for non-existent counter (GET /counters)
+    # Author: Aviendha Andrus
+    # Date: 2025-02-06
+    # Description: Returns a 404 error when attempting to retrieve a 
+    # counter that does not exist.
+    # ===========================
+    def test_get_nonexistent_counter(self, client):
+        """It should return 404 when retrieving a non-existent counter"""
+        name = '/counters/non_existent'
+        result = client.get(name)
+        assert result.status_code == status.HTTP_404_NOT_FOUND
+        assert result.json == {"error": "Counter not found"}
+
+    # ===========================
     # Test: Lists all the counters
     # Author: Christopher Liscano
     # Date: 2025-02-04


### PR DESCRIPTION
Added a test case to tests/test_counter.py that returns a 404 error when attempting to retrieve a counter that does not exist, then implemented it in src/counter.py.