### PR TITLE
Added missing assertion for Student 5 test case

### DIFF
--- a/ci_lab/tests/test_counter.py
+++ b/ci_lab/tests/test_counter.py
@@ -181,6 +181,7 @@ class TestCounterEndpoints:
         assert response_negative.status_code == HTTPStatus.BAD_REQUEST  
         
         # TODO: Add an assertion to verify the response message contains a clear error
+        assert response_negative.get_json() == {"error": "Counter value cannot be negative"}
 
     # ===========================
     # Test: Reset a single counter


### PR DESCRIPTION
Pull request for adding an assertion to test case 5 that checks if the response message contains the proper error message.
```
assert response_negative.get_json() == {"error": "Counter value cannot be negative"}
```