### PR TITLE
Task 2.3 Adding complex code file

### DIFF
--- a/gen_ai/task2.3/AshleyArellano_model.py
+++ b/gen_ai/task2.3/AshleyArellano_model.py
@@ -1,0 +1,38 @@
+# From 2024-F-GROUP3-RebelHub/backend/Private_Messaging/models.py
+from django.db import models
+from django.contrib.auth.models import User  
+from django.core.files.storage import default_storage
+import os
+
+# Create your models here.
+def user_directory_path(instance, filename):
+    return f'users/{instance.user.id}/profile/{filename}'
+
+def get_default_username():
+    return User.objects.first().username if User.objects.exists() else 'no_username'
+
+class Profile(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    bio = models.TextField(blank=True, null=True, max_length=300)
+    created_at = models.DateTimeField(auto_now_add=True)
+    pfp = models.ImageField(upload_to=user_directory_path, default='defaultpfp.png')
+    name = models.CharField(max_length=50, default=get_default_username)
+
+    def __str__(self):
+        return f"{self.user.username}'s Profile"
+    
+    @property
+    def hubs_count(self):
+        return (
+            self.user.joined_hubs.count()
+        )
+
+    def save(self, *args, **kwargs):
+        if self.pk:
+            old_pfp = Profile.objects.get(pk=self.pk).pfp
+
+            if old_pfp and old_pfp != self.pfp and old_pfp.name != 'defaultpfp.png':
+                if os.path.isfile(old_pfp.path):
+                    os.remove(old_pfp.path)
+
+        super(Profile,self).save(*args, **kwargs)


### PR DESCRIPTION
Link to Chatgpt: https://chatgpt.com/share/67b9967d-e74c-8006-94cf-9d73b6141d43

Reference the issue you created and explain the goal of simplifying or optimizing the code in the PR description.
This PR references #122
Chatgpt optimized the code to:
```
from django.db import models
from django.contrib.auth.models import User  
from django.core.files.storage import default_storage
import os

def user_directory_path(instance, filename):
    return f'users/{instance.user.id}/profile/{filename}'

def get_default_username():
    return User.objects.first().username if User.objects.exists() else 'no_username'

class Profile(models.Model):
    user = models.OneToOneField(User, on_delete=models.CASCADE, db_index=True)
    bio = models.TextField(blank=True, null=True, max_length=300)
    created_at = models.DateTimeField(auto_now_add=True)
    pfp = models.ImageField(upload_to=user_directory_path, default='defaultpfp.png')
    name = models.CharField(max_length=50, blank=True, null=True)

    def __str__(self):
        return f"{self.user.username}'s Profile"
    
    @property
    def hubs_count(self):
        return self.user.joined_hubs.count()

    def save(self, *args, **kwargs):
        if self.pk:
            old_pfp = Profile.objects.get(pk=self.pk).pfp
            if old_pfp and old_pfp != self.pfp and old_pfp.name != 'defaultpfp.png':
                if os.path.isfile(old_pfp.path):
                    old_pfp.delete(save=False)

        # Set the default name if not provided
        if not self.name:
            self.name = get_default_username()

        super(Profile, self).save(*args, **kwargs)

```
The goal of this optimization is to add edges cases to avoid scenarios where something does not exist and making the safe() method and retrieving the queries more efficient.